### PR TITLE
updating Chrome download URL for M1 macs

### DIFF
--- a/pyderman/drivers/chrome.py
+++ b/pyderman/drivers/chrome.py
@@ -26,8 +26,8 @@ def get_url(
     if not resolved_version:
         raise ValueError(f"Unable to locate ChromeDriver version! [{version}]")
     if _os == "mac-m1":
-        _os = "mac"  # chromedriver_mac64_m1
-        _os_bit = "%s_m1" % _os_bit
+        _os = "mac"  # chromedriver_mac_arm64
+        _os_bit = "_arm%s" % _os_bit
     download = _base_download.format(version=resolved_version, os=_os, os_bit=_os_bit)
     return "chromedriver", download, resolved_version
 

--- a/pyderman/drivers/chrome.py
+++ b/pyderman/drivers/chrome.py
@@ -26,8 +26,12 @@ def get_url(
     if not resolved_version:
         raise ValueError(f"Unable to locate ChromeDriver version! [{version}]")
     if _os == "mac-m1":
-        _os = "mac"  # chromedriver_mac_arm64
-        _os_bit = "_arm%s" % _os_bit
+        _os = "mac"
+        version_tuple = tuple(map(int, resolved_version.split(".")))
+        if version_tuple > (106, 0, 5249, 21):
+            _os_bit = "_arm%s" % _os_bit  # chromedriver_mac_arm64
+        else:
+            _os_bit = "%s_m1" % _os_bit  # chromedriver_mac64_m1
     download = _base_download.format(version=resolved_version, os=_os, os_bit=_os_bit)
     return "chromedriver", download, resolved_version
 


### PR DESCRIPTION
Older URLs until 105:
`https://chromedriver.storage.googleapis.com/105.0.5195.19/chromedriver_mac64_m1.zip`

New URLs, confirmed 106, 107, 108:
`https://chromedriver.storage.googleapis.com/108.0.5359.22/chromedriver_mac_arm64.zip`